### PR TITLE
Incorrect battery type

### DIFF
--- a/drivers/HKZW-DWS01/driver.compose.json
+++ b/drivers/HKZW-DWS01/driver.compose.json
@@ -56,7 +56,7 @@
     "measure_battery"
   ],
   "energy": {
-    "batteries": [ "AA", "AA"]
+    "batteries": [ "AAA", "AAA"]
   },
   "images": {
     "large": "/drivers/HKZW-DWS01/assets/images/large.png",


### PR DESCRIPTION
I believe this sensor is using AAA batteries, not AA.